### PR TITLE
log test case title as attribute to report portal in runtime

### DIFF
--- a/build/entities.js
+++ b/build/entities.js
@@ -23,16 +23,16 @@ class StartTestItem {
             // @tag1 @tag2 Test for a feature
             //
             // or the actual test scenario, like:
-            // @tag3, @tag4: test for a specific senceario
+            // @tag3, @tag4: test for a specific scenario
             //
             // on these 2 cases, we parse out the test name
-            // and send it over to report portal as attribute so each test feture / scenario
+            // and send it over to report portal as attribute so each test feature / scenario
             // can be uniquely identified via the attribute to create dashboard that
-            // can drilled down to individual test case level
-            const testName = this.name.match(/: (.+$)/);
-            if (testName && testName.length > 1) {
-                const title = testName[1].replace(/ /g, '-');
-                this.attributes.push(new ReporterOptions_1.Attribute("title", title));
+            // can drill down to individual test case level
+            let testTitle = utils_1.parseTitle(this.name);
+            if (testTitle) {
+                testTitle = testTitle.replace(/ /g, '-');
+                this.attributes.push(new ReporterOptions_1.Attribute("title", testTitle));
             }
         }
     }

--- a/build/entities.js
+++ b/build/entities.js
@@ -19,6 +19,21 @@ class StartTestItem {
             const attrs = tags.map((value) => (new ReporterOptions_1.Attribute("tag", value)));
             this.attributes.push(new ReporterOptions_1.Attribute("func", tags[0]));
             this.attributes.push(...attrs);
+            // if tags are detected, it's either the name of test feature, like:
+            // @tag1 @tag2 Test for a feature
+            //
+            // or the actual test scenario, like:
+            // @tag3, @tag4: test for a specific senceario
+            //
+            // on these 2 cases, we parse out the test name
+            // and send it over to report portal as attribute so each test feture / scenario
+            // can be uniquely identified via the attribute to create dashboard that
+            // can drilled down to individual test case level
+            const testName = this.name.match(/: (.+$)/);
+            if (testName && testName.length > 1) {
+                const title = testName[1].replace(/ /g, '-');
+                this.attributes.push(new ReporterOptions_1.Attribute("title", title));
+            }
         }
     }
 }

--- a/build/utils.d.ts
+++ b/build/utils.d.ts
@@ -10,6 +10,7 @@ export declare const limit: (val: any) => any;
 export declare const addBrowserParam: (browser: string, testItem: StartTestItem) => void;
 export declare const addDescription: (description: string, testItem: StartTestItem) => void;
 export declare const parseTags: (text: string) => string[];
+export declare const parseTitle: (text: string) => string;
 export declare const isScreenshotCommand: (command: any) => boolean;
 export declare const sendToReporter: (event: any, msg?: {}) => void;
 export declare const getBrowserstackURL: (capabilities: {

--- a/build/utils.js
+++ b/build/utils.js
@@ -19,6 +19,7 @@ const ARRLENGTH = 10;
 const STRINGLIMIT = 1000;
 const STRINGTRUNCATE = 200;
 const TAGS_PATTERN = /\B@[a-z0-9_-]+/gi;
+const TC_TITLE_PATTERN = /: (.+$)/;
 const log = logger_1.default("wdio-reportportal-reporter");
 exports.promiseErrorHandler = (promise) => {
     promise.catch((err) => {
@@ -92,6 +93,13 @@ exports.addDescription = (description, testItem) => {
     }
 };
 exports.parseTags = (text) => ("" + text).match(TAGS_PATTERN) || [];
+exports.parseTitle = (text) => {
+    const regex = text.match(TC_TITLE_PATTERN);
+    if (regex && regex.length > 1) {
+        return regex[1];
+    }
+    return undefined;
+};
 exports.isScreenshotCommand = (command) => {
     const isScrenshotEndpoint = /\/session\/[^/]*\/screenshot/;
     return isScrenshotEndpoint.test(command.endpoint);

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -1,5 +1,5 @@
 import {STATUS, TYPE} from "./constants";
-import {parseTags} from "./utils";
+import {parseTags,parseTitle} from "./utils";
 import {Attribute} from "./ReporterOptions";
 
 export class StartTestItem {
@@ -31,16 +31,16 @@ export class StartTestItem {
       // @tag1 @tag2 Test for a feature
       //
       // or the actual test scenario, like:
-      // @tag3, @tag4: test for a specific senceario
+      // @tag3, @tag4: test for a specific scenario
       //
       // on these 2 cases, we parse out the test name
-      // and send it over to report portal as attribute so each test feture / scenario
+      // and send it over to report portal as attribute so each test feature / scenario
       // can be uniquely identified via the attribute to create dashboard that
-      // can drilled down to individual test case level
-      const testName = this.name.match(/: (.+$)/);
-      if (testName && testName.length > 1) {
-        const title = testName[1].replace(/ /g, '-');
-        this.attributes.push(new Attribute("title", title));
+      // can drill down to individual test case level
+      let testTitle = parseTitle(this.name);
+      if (testTitle) {
+        testTitle = testTitle.replace(/ /g, '-');
+        this.attributes.push(new Attribute("title", testTitle));
       }
     }
   }

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -26,6 +26,22 @@ export class StartTestItem {
       const attrs = tags.map((value) => (new Attribute("tag", value)));
       this.attributes.push(new Attribute("func", tags[0]));
       this.attributes.push(...attrs);
+
+      // if tags are detected, it's either the name of test feature, like:
+      // @tag1 @tag2 Test for a feature
+      //
+      // or the actual test scenario, like:
+      // @tag3, @tag4: test for a specific senceario
+      //
+      // on these 2 cases, we parse out the test name
+      // and send it over to report portal as attribute so each test feture / scenario
+      // can be uniquely identified via the attribute to create dashboard that
+      // can drilled down to individual test case level
+      const testName = this.name.match(/: (.+$)/);
+      if (testName && testName.length > 1) {
+        const title = testName[1].replace(/ /g, '-');
+        this.attributes.push(new Attribute("title", title));
+      }
     }
   }
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,8 @@ const ARRLENGTH = 10;
 const STRINGLIMIT = 1000;
 const STRINGTRUNCATE = 200;
 const TAGS_PATTERN = /\B@[a-z0-9_-]+/gi;
+const TC_TITLE_PATTERN = /: (.+$)/;
+
 const log = logger("wdio-reportportal-reporter");
 
 export const promiseErrorHandler = (promise: Promise<any>) => {
@@ -88,6 +90,14 @@ export const addDescription = (description: string, testItem: StartTestItem) => 
 };
 
 export const parseTags = (text: string): string[] => ("" + text).match(TAGS_PATTERN) || [];
+
+export const parseTitle = (text: string): string | undefined => {
+  const regex = text.match(TC_TITLE_PATTERN);
+  if (regex && regex.length > 1) {
+    return regex[1];
+  }
+  return undefined;
+}
 
 export const isScreenshotCommand = (command: any) => {
   const isScrenshotEndpoint = /\/session\/[^/]*\/screenshot/;


### PR DESCRIPTION
## Proposed changes

Log the test case title in run time as `attribute` such that it's easy to create report portal dashboard with the component check widget on each individual test status.

Screenshots below:
Feature level:
![Screen Shot 2020-08-12 at 11 18 59 AM](https://user-images.githubusercontent.com/27311858/90053039-ceba3d00-dc8e-11ea-9240-c7c015f9929f.png)

Scenario level:
![Screen Shot 2020-08-12 at 11 19 12 AM](https://user-images.githubusercontent.com/27311858/90053055-d37ef100-dc8e-11ea-908d-3695fbc5a120.png)

Component dash:
![Screen Shot 2020-08-12 at 11 20 37 AM](https://user-images.githubusercontent.com/27311858/90053065-d5e14b00-dc8e-11ea-889c-106be4cc5500.png)
