### PR TITLE
handle test retry probably in report portal reporter

### DIFF
--- a/build/reporter.js
+++ b/build/reporter.js
@@ -73,6 +73,10 @@ class ReportPortalReporter extends reporter_1.default {
             }
         }
         if (this.options.useBrowserStack && this.options.cucumberNestedSteps && suite.type === constants_1.CUCUMBER_TYPE.SCENARIO) {
+            // tells report reportal that the test scenario is retry-able
+            if (this.options.setRetryTrue) {
+                suiteStartObj.retry = true;
+            }
             this.bsUrlPromise = utils_1.getBrowserstackURL(this.capabilities);
         }
         const suiteItem = this.storage.getCurrentSuite();
@@ -223,6 +227,7 @@ class ReportPortalReporter extends reporter_1.default {
             id: this.launchId,
             mode: this.options.reportPortalClientConfig.mode,
             attributes: this.options.reportPortalClientConfig.attributes,
+            rerun: this.options.setRetryTrue,
         };
         const { tempId } = this.client.startLaunch(startLaunchObj);
         this.tempLaunchId = tempId;

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -91,6 +91,10 @@ class ReportPortalReporter extends Reporter {
 
 
     if (this.options.useBrowserStack && this.options.cucumberNestedSteps && suite.type === CUCUMBER_TYPE.SCENARIO) {
+      // tells report reportal that the test scenario is retry-able
+      if (this.options.setRetryTrue) {
+        suiteStartObj.retry = true;
+      }
       this.bsUrlPromise = getBrowserstackURL(this.capabilities);
     }
 
@@ -263,11 +267,13 @@ class ReportPortalReporter extends Reporter {
     this.client = client || new ReportPortalClient(this.options.reportPortalClientConfig);
     this.launchId = process.env.RP_LAUNCH_ID;
     this.specFile = runner.specs[0];
+
     const startLaunchObj = {
       description: this.options.reportPortalClientConfig.description,
       id: this.launchId,
       mode: this.options.reportPortalClientConfig.mode,
       attributes: this.options.reportPortalClientConfig.attributes,
+      rerun: this.options.setRetryTrue, // set rerun for the launch
     };
     const {tempId} = this.client.startLaunch(startLaunchObj);
     this.tempLaunchId = tempId;


### PR DESCRIPTION
## Proposed changes
I want to make use of the `Retried test case (retry)` feature outlined in the report portal [doc](http://reportportal.io/documentation/documentation.html) but it didn't work as is!

looks like the report portal reporter isn't passing retry probably to report portal from webdriverIO when sending over data to report portal server! per this [discussion thread](https://github.com/reportportal/agent-net-specflow/issues/36#issuecomment-459999308), there are 2 things to be done:

1. the test launch will have to be marked `retry=true` if we want to use retry, and,
2. each test scenario will have to be marked `retry` in order to have report portal reported and grouped retry test cases probably.

This change really completed these 2 steps! Merging this is fine as we are not using `this.options.setRetryTrue` from Delos side (yet; i will have another PR to just do exactly that)!

